### PR TITLE
Update Logger.swift to prevent error passing interpolated strings

### DIFF
--- a/Bluebird/src/Logger.swift
+++ b/Bluebird/src/Logger.swift
@@ -89,7 +89,7 @@ class Logger {
     :param: method       Implicity parameter, method that was called
     :param: line         Implicit parameter, line which the call was made
     */
-    func logMessage(message: StaticString , _ logLevel: LoggerLevels = .Info, file: String = __FILE__, method: String = __FUNCTION__, line: UWord = __LINE__) {
+    func logMessage(message: String , _ logLevel: LoggerLevels = .Info, file: String = __FILE__, method: String = __FUNCTION__, line: UWord = __LINE__) {
 
         var outputMessage: String = ""
 


### PR DESCRIPTION
Change the type of message parameter from StaticString to String for the logMessage function in order to accept interpolated strings.

For example, the error `Cannot invoke 'logMessage' with an argument list of type ...` occurs when building an app with the below code snippet contained in a separate ViewController.swift that calls the logMessage function using an interpolated string in the message parameter, however no error occurs when a plain string with no interpolation is used.

```
    #if DEBUG
        Logger().logMessage("Logged in... (Existing Access Token: \(FBSDKAccessToken.currentAccessToken()))", LoggerLevels.Success, file: self.getClassName(), method:String(__FUNCTION__), line: __LINE__)
    #endif
```

But then after changing the logMessage function of Logger.swift to accept a message parameter with type `String` instead of `StaticString` and building the app with the above code snippet containing the interpolated string, no errors occur, and the console outputs the following:

`Logged in... (Existing Access Token: <FBSDKAccessToken: 0x7fb20b726330>) [ViewController:viewDidLoad():61] [18:58:43.GMT-3]`
